### PR TITLE
initial draft of contributing github docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,10 @@
 ## Overview
-In general, this project is only a documentation or onboarding hub.  Please be kind and respectful to each other, be it in GitHub, Slack, or of course real life.
-This project is intended to be open and accessible, for the community by the community.
+In general, this project is intended to a documentation and onboarding hub so please be kind and respectful to each other, be it in GitHub, Slack, or of course real life.
 
 For our general contributing guidelines, please see the [wiki](https://github.com/ProvidenceGeeks/website-docs/wiki)
 
 ## Documentation
-As this repository is going to be specific to documentation, please keep the following in mind when submitting docs:
+As this repository is going to be mostly specific to documentation, please keep the following in mind when submitting docs:
 1.  Think about the topic from someone not as close to it as you.  Start from the beginning and try to avoid assumptions.
 1.  Avoid acronyms, or better yet, write it all out _with_ the acronym, eg. Amazon Web Services (AWS).  Later in the documentation, feel free to use the acronym.
 1.  Spell check and proofread please :)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+## Overview
+In general, this project is only a documentation or onboarding hub.  Please be kind and respectful to each other, be it in GitHub, Slack, or of course real life.
+This project is intended to be open and accessible, for the community by the community.
+
+For our general contributing guidelines, please see the [wiki](https://github.com/ProvidenceGeeks/website-docs/wiki)
+
+## Documentation
+As this repository is going to be specific to documentation, please keep the following in mind when submitting docs:
+1.  Think about the topic from someone not as close to it as you.  Start from the beginning and try to avoid assumptions.
+1.  Avoid acronyms, or better yet, write it all out _with_ the acronym, eg. Amazon Web Services (AWS).  Later in the documentation, feel free to use the acronym.
+1.  Spell check and proofread please :)
+1.  Pictures and diagrams can spruce up any technical documentation.  Use a hosting service like Flickr or Imgur to host images for your docs!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,9 +17,9 @@ As much as can be done with a documentation proposal, please clarify as best you
 "done" would look like and what the value intended is.
 
 A great way to provide this is with an outline, e.g.
-1. [ ] - Intro
-1. [ ] - Topic 1
-1. [ ] - Topic 2
-1. [ ] - Topic 3
-1. [ ] - Conclusion
+1. Intro
+1. Topic 1
+1. Topic 2
+1. Topic 3
+1. Conclusion
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Keep in mind this project is acting as a documentation / onboarding hub primarily.
+If you have a bug or feature request with a specific product, please open the issue there.
+
+Thanks!
+-->
+
+## Type of Change
+- [ ] New Documentation
+- [ ] Update to existing documentation
+- [ ] Other (please clarify below)
+
+
+## Summary
+<!--
+As much as can be done with a documentation proposal, please clarify as best you can what
+"done" would look like and what the value intended is.
+
+A great way to provide this is with an outline, e.g.
+1. [ ] - Intro
+1. [ ] - Topic 1
+1. [ ] - Topic 2
+1. [ ] - Topic 3
+1. [ ] - Conclusion
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,10 +13,11 @@ Please make sure the following criteria are met before submitting your pull requ
 <!-- Include a link to the issue (e.g. #12) -->
 
 ## Summary of Changes
-<!-- Briefly summarize the changes made, lists are also appreciated
+<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
+"TO DO" checklist is also helpful for reviewers
 
-1. Thing I fixed
-1. Other thing I updated
-1. etc
+1. [x] Thing I fixed
+1. [x] Other thing I updated
+1. [x] Docs I updated
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+## Submitting a Pull Request
+We love PRs and appreciate any help you can offer!
+
+Please make sure the following criteria are met before submitting your pull request.
+
+1. <strong>PR meets the Contributing Guidelines (see above)</strong>
+2. Ensure the test suite passes
+3. Make sure your code lints
+-->
+
+## Related Issue
+<!-- Include a link to the issue (e.g. #12) -->
+
+## Summary of Changes
+<!-- Briefly summarize the changes made, lists are also appreciated
+
+1. Thing I fixed
+1. Other thing I updated
+1. etc
+
+-->


### PR DESCRIPTION
resolves #1  and will introduce some GitHub specific templates to this repo for when issues and PRs are opened.

This can be applied to other repositories with more / less information as needed on a per project bases.

Also, please see the wiki Home Page!
https://github.com/ProvidenceGeeks/website-docs/wiki